### PR TITLE
Add an init method to force linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,5 @@ version = "0.1.0"
 license = "MIT/Apache 2.0"
 edition = "2021"
 
-[lib]
-name = "pthread_3ds"
-path = "src/lib.rs"
-crate-type = ["staticlib", "lib"]
-
-[dependencies.libc]
-git = "https://github.com/Meziu/libc.git"
+[dependencies]
+libc = { git = "https://github.com/Meziu/libc.git" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
 #![feature(thread_local)]
 #![allow(non_camel_case_types)]
 
+/// Call this somewhere to force Rust to link this module.
+/// The call doesn't need to execute, just exist.
+///
+/// See https://github.com/rust-lang/rust/issues/47384
+pub fn init() {}
+
 // LIBCTRU THREADS
 
 pub type _LOCK_T = i32;


### PR DESCRIPTION
Also simplified Cargo.toml and removed staticlib crate type (default is lib).

Rustc bug causing this workaround: https://github.com/rust-lang/rust/issues/47384