### PR TITLE
Make thread keys impl thread-safe and handle invalid keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.116"
+once_cell = "1.0"


### PR DESCRIPTION
We still don't actually run the destructors... Which could be fine, but we should probably run them somewhere.

I have a feeling we might also need to look at this though:
https://github.com/devkitPro/libctru/blob/master/libctru/source/internal.h