### PR TITLE
Fix some bugs breaking Tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2.116"
-once_cell = "1.0"
+spin = { version = "0.9", default-features = false, features = ["rwlock", "std"] }


### PR DESCRIPTION
See the commit messages for the fine details. Overall this fixes a deadlock in pthread keys and a few bugs in `pthread_cond_timedwait`. These bugs were breaking https://github.com/Meziu/ctru-rs/pull/42.