### PR TITLE
More changes for pthread threading support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,10 @@ pub unsafe extern "C" fn pthread_create(
 
     if handle.is_null() {
         // There was some error, but libctru doesn't expose the result.
-        // We assume there was an incorrect parameter (such as too low of a priority).
+        // We assume there was permissions issue (such as too low of a priority).
         // We also need to clean up the closure at this time.
         drop(Box::from_raw(main));
-        return libc::EINVAL;
+        return libc::EPERM;
     }
 
     *native = handle as _;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,11 @@ pub unsafe extern "C" fn pthread_setschedparam(
     0
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn pthread_getprocessorid_np() -> libc::c_int {
+    ctru_sys::svcGetProcessorID()
+}
+
 /// Internal struct for storing pthread attribute data
 /// Must be less than or equal to the size of `libc::pthread_attr_t`. We assert
 /// this below via static_assertions.


### PR DESCRIPTION
Implements some more pthread functions for https://github.com/Meziu/rust-horizon/pull/10.

Requires https://github.com/Meziu/libc/pull/7.

The first commit I actually forgot to push in the last PR, but the rest of the changes are generally to use more standard interfaces.