### PR TITLE
Use struct pointer as pthread_t

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn pthread_create(
 
             // destruct the THREAD_SELF variable, if it was ever created
             if let Some(p) = THREAD_SELF {
-                let _ = Box::from_raw(p);
+                drop(Box::from_raw(p));
             }
 
             // Destruct thread local values where possible. We can't guarantee destructors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::missing_safety_doc)]
 
-// TODO: should this crate be no_std? I don't think we actually use any std features...
-
 use core::mem::{self, MaybeUninit};
 use core::ptr;
 
@@ -96,7 +94,7 @@ pub unsafe extern "C" fn pthread_create(
 
     let res = ctru_sys::svcGetThreadId(&mut os_thread, os_handle);
     if ctru_sys::R_FAILED(res) {
-        // todo error handling...
+        // TODO: improve error handling? Different codes?
         return libc::EPERM;
     }
 
@@ -144,7 +142,7 @@ pub unsafe extern "C" fn pthread_self() -> libc::pthread_t {
     let res = ctru_sys::svcGetThreadId(&mut os_thread, ctru_sys::CUR_THREAD_HANDLE);
 
     if ctru_sys::R_FAILED(res) {
-        // todo err
+        // TODO: some way to report error? This should probably normally never fail...
         ptr::null_mut::<PThread>() as libc::pthread_t
     } else {
         let pthread = Box::new(PThread { thread, os_thread });


### PR DESCRIPTION
https://github.com/Meziu/ctru-rs/issues/48

This allows us to hold the OS thread ID as well as the ctru `Thread`, which makes lookups for schedparam work a bit nicer. One downside is that `pthread_self` leaks the struct when called...

I considered trying to stuff the whole `PThread` struct into the `pthread_t` (if it were a `c_ulonglong` instead of `c_ulong`), but it requires `mem::transmute`, and I tried it in Miri and it was flagged as Undefined Behavior (and also didn't seem to work), so ... probably not the best idea.

Open to ideas for avoiding the leak, although arguably leaking a 64-bit struct once in a while is not so bad compared to the zombie processing getting left around by `svcGetThreadList`.

@Meziu @AzureMarker 