### PR TITLE
Fix link errors by using inlining

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,13 @@ mod thread_keys;
 /// The call doesn't need to execute, just exist.
 ///
 /// See https://github.com/rust-lang/rust/issues/47384
+#[inline(always)]
 pub fn init() {
     condvar::init();
     misc::init();
     mutex::init();
     rwlock::init();
     thread::init();
+    thread::attr::init();
     thread_keys::init();
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -6,11 +6,9 @@ use std::collections::BTreeMap;
 use std::ptr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-mod attr;
+pub mod attr;
 
-pub fn init() {
-    attr::init();
-}
+pub fn init() {}
 
 /// The main thread's pthread ID
 const MAIN_THREAD_ID: libc::pthread_t = 0;


### PR DESCRIPTION
Fixes https://github.com/Meziu/ctru-rs/issues/51

The release build (ex. for ctru-rs examples) was doing some extra optimizations and throwing away the submodules of this crate after the refactor split it into multiple files.

For some reason if the init call is behind another function call, it is as if it doesn't exist. Luckily forcing inlining makes sure the module doesn't get thrown away.

The `thread::attr` init call also needs to appear in the top level init, otherwise you still get link errors.