### PR TITLE
Add pthread_condattr functions

### DIFF
--- a/src/condvar.rs
+++ b/src/condvar.rs
@@ -82,3 +82,38 @@ pub unsafe extern "C" fn pthread_cond_timedwait(
 pub unsafe extern "C" fn pthread_cond_destroy(_cond: *mut libc::pthread_cond_t) -> libc::c_int {
     0
 }
+
+#[no_mangle]
+pub extern "C" fn pthread_condattr_init(_attr: *const libc::pthread_condattr_t) -> libc::c_int {
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn pthread_condattr_destroy(_attr: *const libc::pthread_condattr_t) -> libc::c_int {
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn pthread_condattr_getclock(
+    _attr: *const libc::pthread_condattr_t,
+    clock_id: *mut libc::clockid_t,
+) -> libc::c_int {
+    unsafe {
+        *clock_id = libc::CLOCK_REALTIME;
+    }
+
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn pthread_condattr_setclock(
+    _attr: *mut libc::pthread_condattr_t,
+    clock_id: libc::clockid_t,
+) -> libc::c_int {
+    // only one clock is supported, so all other options are considered an error
+    if clock_id == libc::CLOCK_REALTIME {
+        0
+    } else {
+        libc::EINVAL
+    }
+}


### PR DESCRIPTION
These, plus `libc` definitions, should allow us to compile `bevy_ecs`, which seems like it would be really cool for development on the 3DS!

Best I can tell, there is no way to control the clock behavior of
condvars using libctru - so, simply fail if the user tries to set
anything other than CLOCK_REALTIME.

Will open a corresponding libc PR shortly.

@AzureMarker @Meziu 