### PR TITLE
Add no-op pthread_atfork

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -17,3 +17,12 @@ pub unsafe extern "C" fn pthread_sigmask(
 ) -> ::libc::c_int {
     -1
 }
+
+#[no_mangle]
+pub extern "C" fn pthread_atfork(
+    _prepare: Option<unsafe extern "C" fn()>,
+    _parent: Option<unsafe extern "C" fn()>,
+    _child: Option<unsafe extern "C" fn()>,
+) -> libc::c_int {
+    0
+}


### PR DESCRIPTION
The `rand` crate uses this for implementing fork protection: https://github.com/rust-random/rand/blob/master/src/rngs/adapter/reseeding.rs#L321

As far as I know, there's no support for forking on 3ds, so just a no-op here (with success exit code) should be safe enough. We can always go back and implement it later if forking does become supported.

@AzureMarker @Meziu 